### PR TITLE
Minimum support for hybi13

### DIFF
--- a/src/trans-websocket.coffee
+++ b/src/trans-websocket.coffee
@@ -27,7 +27,7 @@ exports.app =
         location += '://' + req.headers.host + req.url
 
         ver = req.headers['sec-websocket-version']
-        if  ver is '8' or ver is '7'
+        if ver in ['7', '8', '13']
             new websocket_hybi10.WebHandshake8(@, req, connection, head or '', origin, location)
         else
             new websocket_hixie76.WebHandshakeHixie76(@, req, connection, head or '', origin, location)


### PR DESCRIPTION
Chrome Canary builds are now using websocket protocol version 13, from [draft-ietf-hybi-thewebsocketprotocol-17](http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-17). This commit basically matches the work done in the related [WebKit commit](http://trac.webkit.org/changeset/97249) and [pywebsocket commit](http://code.google.com/p/pywebsocket/source/detail?r=563).
