### PR TITLE
Access request from connection

### DIFF
--- a/src/trans-eventsource.coffee
+++ b/src/trans-eventsource.coffee
@@ -19,6 +19,6 @@ exports.app =
         # Opera needs one more new line at the start.
         res.write('\r\n')
 
-        session = transport.Session.bySessionIdOrNew(req.session, @)
+        session = transport.Session.bySessionIdOrNew(req.session, @, req)
         session.register( new EventSourceReceiver(res, @options) )
         return true

--- a/src/trans-htmlfile.coffee
+++ b/src/trans-htmlfile.coffee
@@ -43,6 +43,6 @@ exports.app =
         res.writeHead(200)
         res.write(iframe_template.replace(/{{ callback }}/g, callback));
 
-        session = transport.Session.bySessionIdOrNew(req.session, @)
+        session = transport.Session.bySessionIdOrNew(req.session, @, req)
         session.register( new HtmlFileReceiver(res, @options) )
         return true

--- a/src/trans-jsonp.coffee
+++ b/src/trans-jsonp.coffee
@@ -26,7 +26,7 @@ exports.app =
         res.setHeader('Content-Type', 'application/javascript; charset=UTF-8')
         res.writeHead(200)
 
-        session = transport.Session.bySessionIdOrNew(req.session, @)
+        session = transport.Session.bySessionIdOrNew(req.session, @, req)
         session.register( new JsonpReceiver(res, @options, callback) )
         return true
 

--- a/src/trans-websocket-hixie76.coffee
+++ b/src/trans-websocket-hixie76.coffee
@@ -100,7 +100,7 @@ class WebHandshakeHixie76
                 return false
 
         # websockets possess no session_id
-        session = transport.Session.bySessionIdOrNew(undefined, @server)
+        session = transport.Session.bySessionIdOrNew(undefined, @server, @req)
         session.register( new WebSocketReceiver(@connection) )
 
 

--- a/src/trans-websocket-hybi10.coffee
+++ b/src/trans-websocket-hybi10.coffee
@@ -30,7 +30,7 @@ class WebHandshake8
             return
 
         # websockets possess no session_id
-        session = transport.Session.bySessionIdOrNew(undefined, @server)
+        session = transport.Session.bySessionIdOrNew(undefined, @server, @req)
         session.register( new WebSocket8Receiver(@connection) )
 
 

--- a/src/trans-xhr.coffee
+++ b/src/trans-xhr.coffee
@@ -63,7 +63,7 @@ exports.app =
         res.setHeader('Content-Type', 'application/javascript; charset=UTF-8')
         res.writeHead(200)
 
-        session = transport.Session.bySessionIdOrNew(req.session, @)
+        session = transport.Session.bySessionIdOrNew(req.session, @, req)
         session.register( new XhrPollingReceiver(res, @options) )
         return true
 
@@ -75,6 +75,6 @@ exports.app =
         #  http://blogs.msdn.com/b/ieinternals/archive/2010/04/06/comet-streaming-in-internet-explorer-with-xmlhttprequest-and-xdomainrequest.aspx
         res.write(Array(2049).join('h') + '\n')
 
-        session = transport.Session.bySessionIdOrNew(req.session, @)
+        session = transport.Session.bySessionIdOrNew(req.session, @, req)
         session.register( new XhrStreamingReceiver(res, @options) )
         return true

--- a/src/transport.coffee
+++ b/src/transport.coffee
@@ -47,7 +47,7 @@ SockJSConnection.prototype.__defineGetter__ 'writable', ->
 MAP = {}
 
 class Session
-    constructor: (@session_id, server) ->
+    constructor: (@session_id, server, request) ->
         @heartbeat_delay = server.options.heartbeat_delay
         @disconnect_delay = server.options.disconnect_delay
         @send_buffer = []
@@ -58,6 +58,7 @@ class Session
         @timeout_cb = => @didTimeout()
         @to_tref = setTimeout(@timeout_cb, @disconnect_delay)
         @connection = new SockJSConnection(@)
+        @connection.request = request
         @emit_open = =>
             @emit_open = null
             server.emit('connection', @connection)
@@ -170,10 +171,10 @@ class Session
 Session.bySessionId = (session_id) ->
     return MAP[session_id] or null
 
-Session.bySessionIdOrNew = (session_id, server) ->
+Session.bySessionIdOrNew = (session_id, server, request) ->
     session = Session.bySessionId(session_id)
     if not session
-        session = new Session(session_id, server)
+        session = new Session(session_id, server, request)
     return session
 
 


### PR DESCRIPTION
It'd be great to be able to do something like the following:

```
var handler = sockjs.createServer(options);
handler.on('connection', function(conn) {
    console.log(conn.request.path);
});
```
