### PR TITLE
sockjs_opts variable was missing from de README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ An simplified echo SockJS server could look more or less like:
 var http = require('http');
 var sockjs = require('sockjs');
 
+var sockjs_opts = {sockjs_url: "http://cdn.sockjs.org/sockjs-0.1.min.js"};
+
 var echo = sockjs.createServer(sockjs_opts);
 echo.on('connection', function(conn) {
     conn.on('data', function(message) {


### PR DESCRIPTION
I thought it might be nice to provide a working example in the README, and create a better first impression for new users. 
