### PR TITLE
Upgrade node-uuid dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "repository": {"type": "git",
                        "url": "https://github.com/sockjs/sockjs-node.git"},
         "dependencies": {
-                "node-uuid": "1.2.0",
+                "node-uuid": "1",
                 "faye-websocket": "0.3.x",
                 "rbytes": "0.0.2"
         },


### PR DESCRIPTION
SockJS uses very basic functionality in `node-uuid`, API that won't be going away soon. In my own projects, I've had a dependency like this (on just major version 1) for a while now without any problems.
