### PR TITLE
Fix infinite recursion on 0.7.7.

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -84,7 +84,10 @@ exports.objectExtend = (dst, src) ->
     return dst
 
 exports.overshadowListeners = (ee, event, handler) ->
-    old_listeners = ee.listeners(event)
+    # listeners() returns a reference to the internal array of EventEmitter.
+    # Make a copy, because we're about the replace the actual listeners.
+    old_listeners = ee.listeners(event).slice(0)
+
     ee.removeAllListeners(event)
     new_handler = () ->
         if handler.apply(this, arguments) isnt true


### PR DESCRIPTION
At least on Node.js 0.7.7, we apparently get a reference from `EventEmitter#listeners`, causing infinite recursion in utils' `overshadowListeners`.
