### PR TITLE
Wrap emit, rather than the listeners.

### DIFF
--- a/src/sockjs.coffee
+++ b/src/sockjs.coffee
@@ -150,8 +150,15 @@ class Server extends events.EventEmitter
 
     installHandlers: (http_server, handler_options) ->
         handler = @listener(handler_options).getHandler()
-        utils.overshadowListeners(http_server, 'request', handler)
-        utils.overshadowListeners(http_server, 'upgrade', handler)
+
+        old_emit = http_server.emit
+        http_server.emit = (type, req, res, extra) ->
+            if type in ['request', 'upgrade']
+                return true if handler(req, res, extra)
+                return old_emit.call(this, type, req, res, extra)
+            else
+                return old_emit.apply(this, arguments)
+
         return true
 
     middleware: (handler_options) ->

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -89,20 +89,6 @@ exports.objectExtend = (dst, src) ->
             dst[k] = src[k]
     return dst
 
-exports.overshadowListeners = (ee, event, handler) ->
-    # listeners() returns a reference to the internal array of EventEmitter.
-    # Make a copy, because we're about the replace the actual listeners.
-    old_listeners = ee.listeners(event).slice(0)
-
-    ee.removeAllListeners(event)
-    new_handler = () ->
-        if handler.apply(this, arguments) isnt true
-            for listener in old_listeners
-                listener.apply(this, arguments)
-            return false
-        return true
-    ee.addListener(event, new_handler)
-
 
 escapable = /[\x00-\x1f\ud800-\udfff\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufff0-\uffff]/g
 


### PR DESCRIPTION
This allows adding listeners after `installHandlers`.

I ran benchmarks before and after, and performance is about the same on my system.

Before:

```
Concurrency Level:      100
Time taken for tests:   7.308 seconds
Complete requests:      30000
Failed requests:        0
Write errors:           0
Non-2xx responses:      30000
Total transferred:      3570000 bytes
HTML transferred:       1440000 bytes
Requests per second:    4105.09 [#/sec] (mean)
Time per request:       24.360 [ms] (mean)
Time per request:       0.244 [ms] (mean, across all concurrent requests)
Transfer rate:          477.06 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.8      0     136
Processing:     1   24 115.0     11    1281
Waiting:        1   24 115.0     11    1281
Total:          1   24 115.0     11    1281

Percentage of the requests served within a certain time (ms)
  50%     11
  66%     15
  75%     16
  80%     17
  90%     19
  95%     22
  98%    134
  99%    909
 100%   1281 (longest request)
```

After:

```
Concurrency Level:      100
Time taken for tests:   7.249 seconds
Complete requests:      30000
Failed requests:        0
Write errors:           0
Non-2xx responses:      30000
Total transferred:      3570000 bytes
HTML transferred:       1440000 bytes
Requests per second:    4138.66 [#/sec] (mean)
Time per request:       24.162 [ms] (mean)
Time per request:       0.242 [ms] (mean, across all concurrent requests)
Transfer rate:          480.96 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.3      0       3
Processing:     1   24 110.7     12    1240
Waiting:        1   24 110.4     12    1240
Total:          2   24 110.7     12    1240

Percentage of the requests served within a certain time (ms)
  50%     12
  66%     15
  75%     17
  80%     18
  90%     20
  95%     23
  98%    128
  99%    872
 100%   1240 (longest request)
```
