### PR TITLE
Stop coffeescript from generating a global variable

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -138,11 +138,10 @@ exports.parseCookie = (cookie_header) ->
 
 exports.random32 = () ->
     if rbytes
-        x = rbytes.randomBytes(4)
-        v = [x[0], x[1], x[2], x[3]]
+        foo = rbytes.randomBytes(4)
+        v = [foo[0], foo[1], foo[2], foo[3]]
     else
         foo = -> Math.floor(Math.random()*256)
         v = [foo(), foo(), foo(), foo()]
 
-    x =  v[0] + (v[1]*256 ) + (v[2]*256*256) + (v[3]*256*256*256)
-    return x
+    return  v[0] + (v[1]*256 ) + (v[2]*256*256) + (v[3]*256*256*256)


### PR DESCRIPTION
Mocha will test for global leaks and when testing a project that used SockJS I was getting failures because the random32 function was being compiled by coffeescript incorrectly so that the 'x' variable was globally scoped.

This:

``` coffeescript
exports.random32 = () ->
    if rbytes
        x = rbytes.randomBytes(4)
        v = [x[0], x[1], x[2], x[3]]
    else
        foo = -> Math.floor(Math.random()*256)
        v = [foo(), foo(), foo(), foo()]

    x =  v[0] + (v[1]*256 ) + (v[2]*256*256) + (v[3]*256*256*256)
    return x
```

was getting compiled to:

``` javascript

exports.random32 = function() {
  var foo, v;
  if (rbytes) {
    x = rbytes.randomBytes(4);
    v = [x[0], x[1], x[2], x[3]];
  } else {
    foo = function() {
      return Math.floor(Math.random() * 256);
    };
    v = [foo(), foo(), foo(), foo()];
  }
  x = v[0] + (v[1] * 256) + (v[2] * 256 * 256) + (v[3] * 256 * 256 * 256);
  return x;
};
```

I've made some simple modifications so we re-use the already declared foo variable and don't assign the return to a variable, just return it.
