### PR TITLE
Add "Cache-Control: no-cache" header to /xhr POST requests

### DIFF
--- a/src/sockjs.coffee
+++ b/src/sockjs.coffee
@@ -85,7 +85,7 @@ generate_dispatcher = (options) ->
             ['GET',     p('/websocket'),   ['raw_websocket']],
             ['GET',     t('/jsonp'), ['h_sid', 'h_no_cache', 'jsonp']],
             ['POST',    t('/jsonp_send'), ['h_sid', 'expect_form', 'jsonp_send']],
-            ['POST',    t('/xhr'), ['h_sid', 'xhr_cors', 'xhr_poll']],
+            ['POST',    t('/xhr'), ['h_sid', 'h_no_cache', 'xhr_cors', 'xhr_poll']],
             ['OPTIONS', t('/xhr'), opts_filters()],
             ['POST',    t('/xhr_send'), ['h_sid', 'xhr_cors', 'expect_xhr', 'xhr_send']],
             ['OPTIONS', t('/xhr_send'), opts_filters()],


### PR DESCRIPTION
This should not be required by the standard, but iOS 6 appears to need it.  See
http://stackoverflow.com/questions/12506897/is-safari-on-ios-6-caching-ajax-results

To test this, run `make test_server` and serve this page from HTTP on localhost:

``` html

<html>
<head>
  <title>SockJS test</title>
  <script src="http://cdn.sockjs.org/sockjs-0.3.min.js"></script>
  <script type="text/javascript">
    var sock = new SockJS('http://localhost:8081/disabled_websocket_echo',
        undefined, {protocols_whitelist: ['xhr-polling']});
    var addText = function (text) {
      var li = document.createElement('li');
      li.appendChild(document.createTextNode(text));
      document.getElementById('foo').appendChild(li);
    };
    sock.onopen = function () {
      addText('open');
      sock.send('some data');
    };
    sock.onmessage = function (e) {
      addText('got: ' + e.data);
    };
    sock.onclose = function () {
      addText('closed');
    };
  </script>
</head>
<body>
  <ul id="foo">
  </ul>
</body>
</html>
```

When I load this page in Chrome, it displays "open" followed by "got: some data". When I open it in iOS 6 (eg, in the iOS 6 simulator) without my patch, it displays "open" followed by "closed". With the patch, iOS 6 correctly receives data.

It's a shame to add this theoretically-unnecessary header to all XHR requests just for one buggy OS, but it's a somewhat important OS!

It might be necessary to add it to other POSTs too, but xhr-streaming did appear to work without a similar patch.
