### PR TITLE
Property for the true remote address of a socket

### DIFF
--- a/src/transport.coffee
+++ b/src/transport.coffee
@@ -113,15 +113,17 @@ class Session
         unless socket = @recv.connection
             socket = @recv.response.connection
         try
-            remoteAddress = socket.remoteAddress
-            remotePort    = socket.remotePort
-            address       = socket.address()
+            remoteAddress     = socket.remoteAddress
+            trueRemoteAddress = req.connection.remoteAddress
+            remotePort        = socket.remotePort
+            address           = socket.address()
         catch x
             # All-or-nothing
             return
-        @connection.remoteAddress = remoteAddress
-        @connection.remotePort    = remotePort
-        @connection.address       = address
+        @connection.remoteAddress     = remoteAddress
+        @connection.trueRemoteAddress = trueRemoteAddress
+        @connection.remotePort        = remotePort
+        @connection.address           = address
 
         @connection.url = req.url
         @connection.pathname = req.pathname


### PR DESCRIPTION
In newer versions of Node.js (or at least 0.8.3 that I tested on), `socket.remoteAddress` is replaced by the address in the `X-Forwarded-For` header, if it exists. This header can be spoofed.

This adds `socket.trueRemoteAddress`, for the true remote address of the socket that won't be replaced by a spoofed IP.

For instance, if a user with IP 192.168.0.101 initiates a connection with the header `X-Forwarded-For: 8.8.8.8`, then `socket.remoteAddress === '8.8.8.8'` and `socket.trueRemoteAddress === '192.168.0.101'`.
