### PR TITLE
Add 'host' header to connection objects

### DIFF
--- a/src/transport.coffee
+++ b/src/transport.coffee
@@ -130,7 +130,7 @@ class Session
 
         headers = {}
         for key in ['referer', 'x-client-ip', 'x-forwarded-for', \
-                    'x-cluster-client-ip', 'via', 'x-real-ip']
+                    'x-cluster-client-ip', 'via', 'x-real-ip', 'host']
             headers[key] = req.headers[key] if req.headers[key]
         if headers
             @connection.headers = headers


### PR DESCRIPTION
This makes it possible to use a single SockJS server with multiple
virtual hosts (that each might have unique logic).
