### PR TITLE
Add accept language header

### DIFF
--- a/src/transport.coffee
+++ b/src/transport.coffee
@@ -131,7 +131,7 @@ class Session
         headers = {}
         for key in ['referer', 'x-client-ip', 'x-forwarded-for', \
                     'x-cluster-client-ip', 'via', 'x-real-ip', 'host', \
-                    'user-agent']
+                    'user-agent', 'accept-language']
             headers[key] = req.headers[key] if req.headers[key]
         if headers
             @connection.headers = headers


### PR DESCRIPTION
The accept-language header is useful in determining the language of an unknown user. 
