### PR TITLE
When the server closes a connection, make sure the send buffer still gets flushed.

### DIFF
--- a/src/transport.coffee
+++ b/src/transport.coffee
@@ -83,6 +83,7 @@ class Session
             clearTimeout(@to_tref)
             @to_tref = null
         if @readyState is Transport.CLOSING
+            @flushToRecv(recv)
             recv.doSendFrame(@close_frame)
             recv.didClose()
             @to_tref = setTimeout(@timeout_cb, @disconnect_delay)
@@ -143,11 +144,15 @@ class Session
             clearTimeout(@to_tref)
         @to_tref = setTimeout(@timeout_cb, @disconnect_delay)
 
-    tryFlush: ->
+    flushToRecv: (recv) ->
         if @send_buffer.length > 0
             [sb, @send_buffer] = [@send_buffer, []]
-            @recv.doSendBulk(sb)
-        else
+            recv.doSendBulk(sb)
+            return true
+        return false
+
+    tryFlush: ->
+        if not @flushToRecv(@recv)
             if @to_tref
                 clearTimeout(@to_tref)
             x = =>


### PR DESCRIPTION
On polling protocols, you otherwise do not actually get the final output from the server.  eg:

_server_

``` js
var closer = sockjs.createServer();
closer.on('connection', function(conn) {
  conn.write("first message");
  conn.close();
});
```

_client_

``` js
   var sock = new SockJS('http://127.0.0.1:9999/closer', undefined, {
        protocols_whitelist: [
           'xhr-polling'
        ]});
   sock.onopen = function() {
       console.log('open');
   };
   sock.onmessage = function(e) {
       console.log('message', e.data);
   };
   sock.onclose = function() {
       console.log('close');
   };
```

Without this patch, the client just logs open and close.  With this patch, the client logs the message as well.
