### PR TITLE
Allow servers to specify a base URL in /info.

### DIFF
--- a/src/chunking-test.coffee
+++ b/src/chunking-test.coffee
@@ -37,6 +37,13 @@ exports.app =
             cookie_needed: not not @options.jsessionid,
             entropy: utils.random32(),
         }
+        # Users can specify a new base URL which further requests will be made
+        # against. For example, it may contain a randomized domain name to
+        # avoid browser per-domain connection limits.
+        if typeof @options.base_url is 'function'
+            info.base_url = @options.base_url()
+        else if @options.base_url
+            info.base_url = @options.base_url
         res.setHeader('Content-Type', 'application/json; charset=UTF-8')
         res.writeHead(200)
         res.end(JSON.stringify(info))


### PR DESCRIPTION
See also sockjs/sockjs-client#116.

The goal here is to allow servers to specify a base URL with a random segment in the domain (all of which are routed to the same place), so that different SockJS connections to the same URL (in different tabs, eg) use different domains and don't run into browser per-domain connection limits.
