### PR TITLE
Set Vary: Origin on CORS requests

### DIFF
--- a/src/trans-xhr.coffee
+++ b/src/trans-xhr.coffee
@@ -62,6 +62,7 @@ exports.app =
         else
             origin = req.headers['origin']
         res.setHeader('Access-Control-Allow-Origin', origin)
+        res.setHeader('Vary', 'Origin')
         headers = req.headers['access-control-request-headers']
         if headers
             res.setHeader('Access-Control-Allow-Headers', headers)


### PR DESCRIPTION
So, someone working with one of my sockjs deployments hit on some trouble where the CORS headers of another origin accessing `/info` were used to apply CORS policy. I've yet to reproduce this, and `/info` requests to not be cached anyway, so I'm entirely sure what the cause is. Nevertheless, setting the `Vary` header seems prudent here.

The `Access-Control-Allow-Origin` header is set depending on the request's `Origin` header. Although most requests also send `Cache-Control` headers with `no-cache`, the `OPTIONS` requests for CORS pre-flight requests do set cache headers.

See http://www.w3.org/TR/cors/#resource-implementation
