### PR TITLE
Don't look up session id undefined

### DIFF
--- a/src/transport.coffee
+++ b/src/transport.coffee
@@ -214,6 +214,8 @@ class Session
 
 
 Session.bySessionId = (session_id) ->
+    if not session_id
+        return null
     return MAP[session_id] or null
 
 register = (req, server, session_id, receiver) ->


### PR DESCRIPTION
Otherwise a client can squat session id "undefined" (the string, not the value)
and prevent WebSocket-based transports, with session id undefined (the value),
from connecting.
