### PR TITLE
Renamed license file to standard LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (C) 2011 VMware, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
The standard convention is to specify the license in a file named LICENSE. This makes it easier to programmatically identify the LICENSE in a project.

Thanks!
