### PR TITLE
Fixed vert.x repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SockJS family:
   * [SockJS-node](https://github.com/sockjs/sockjs-node) Node.js server
   * [SockJS-erlang](https://github.com/sockjs/sockjs-erlang) Erlang server
   * [SockJS-tornado](https://github.com/MrJoes/sockjs-tornado) Python/Tornado server
-  * [vert.x](https://github.com/purplefox/vert.x) Java/vert.x server
+  * [vert.x](https://github.com/eclipse/vert.x) Java/vert.x server
 
 Work in progress:
 


### PR DESCRIPTION
The repo seems to have been moved from @purplefox to the @vert-x org, where the repo's README in turn points to @eclipse, where the README says:

> This is the GitHub repository for the main Vert.x main project which is an Eclipse project. For any other parts of Vert.x projects that aren't in Eclipse please look at the vert-x organisation on GitHub.
