### PR TITLE
Upgrade Faye; older versions have zero-day DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
                    "url": "https://github.com/sockjs/sockjs-node.git"},
     "dependencies": {
         "node-uuid"      : "1.3.3",
-        "faye-websocket" : "0.7.0"
+        "faye-websocket" : "0.7.2"
     },
     "devDependencies": {
         "coffee-script"  : "1.2.x"


### PR DESCRIPTION
Hi, many versions of Faye older than 0.7.2 (including 0.7.0 used in SockJS) have a DoS vulnerability that's being actively exploited to take down SockJS servers.

I've worked with @jcoglan to fix it in the latest version of Faye, and since SockJS servers are already being attacked, I'd consider it highly urgent to update and release a new version of SockJS ASAP.
