### PR TITLE
Update header detection for BIG-IP load balancer

### DIFF
--- a/src/trans-websocket.coffee
+++ b/src/trans-websocket.coffee
@@ -18,7 +18,7 @@ exports.app =
                 status: 400
                 message: 'Can "Upgrade" only to "WebSocket".'
             }
-        conn = (req.headers.connection || '').toLowerCase()
+        conn = (req.headers['x-cnection'] || req.headers.connection || '').toLowerCase()
 
         if (conn.split(/, */)).indexOf('upgrade') is -1
             throw {


### PR DESCRIPTION
With the BIG-IP load balancers, the OneConnect feature override the `connection` header and copy its content into the `x-cnection` header ([Documentation](http://support.f5.com/kb/en-us/solutions/public/6000/900/sol6997.html)).

Behind this load balancer SockJS fail to upgrade to WebSocket because it only check the `connection` header for "Upgrade". We should also check the `x-cnection` header.

This patch has no incidences on servers that do not use BIG-IP (the `x-cnection` header does not exists and we fallback to the `connection` header).
