### PR TITLE
#129, #162 add ws ping-pong and close if no response

### DIFF
--- a/src/trans-websocket.coffee
+++ b/src/trans-websocket.coffee
@@ -50,6 +50,7 @@ class WebSocketReceiver extends transport.GenericReceiver
             @connection.setNoDelay(true)
         catch x
         @ws.addEventListener('message', (m) => @didMessage(m.data))
+        @heartbeat_cb = => @heartbeat_timeout()
         super @connection
 
     setUp: ->
@@ -87,6 +88,18 @@ class WebSocketReceiver extends transport.GenericReceiver
         catch x
         @ws = null
         @connection = null
+
+    heartbeat: ->
+        supportsHeartbeats = @ws.ping null, ->
+            clearTimeout(hto_ref)
+
+        if supportsHeartbeats
+            hto_ref = setTimeout(@heartbeat_cb, 10000)
+        else
+            super
+
+    heartbeat_timeout: ->
+        @session.close(3000, 'No response from heartbeat')
 
 
 

--- a/src/transport.coffee
+++ b/src/transport.coffee
@@ -158,7 +158,7 @@ class Session
             x = =>
                 if @recv
                     @to_tref = setTimeout(x, @heartbeat_delay)
-                    @recv.doSendFrame("h")
+                    @recv.heartbeat()
             @to_tref = setTimeout(x, @heartbeat_delay)
         return
 
@@ -263,6 +263,9 @@ class GenericReceiver
         q_msgs = for m in messages
                 utils.quote(m)
         @doSendFrame('a' + '[' + q_msgs.join(',') + ']')
+
+    heartbeat: ->
+        @doSendFrame('h')
 
 
 # Write stuff to response, using chunked encoding if possible.


### PR DESCRIPTION
This utilizes the web socket protocol ping-pong op codes. If the
connection supports them, it will send them instead of heartbeat
frames. If the client doesn’t respond within 10 seconds, it considers
the connection closed.