### PR TITLE
Force coffescript version to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node-uuid": "^1.4.1"
   },
   "devDependencies": {
-    "coffee-script": "^1.8.0"
+    "coffee-script": "1.8.0"
   },
   "homepage": "https://github.com/sockjs/sockjs-node",
   "keywords": [


### PR DESCRIPTION
With newer versións of coffescript ( > 1.8.0 ) the code 
```
class Listener
    constructor: (@options, emit) ->
        @app = new App()
        @app.options = options
```
compiles to
```
Listener = (function() {
    function Listener(options1, emit) {
      this.options = options1;
      this.handler = __bind(this.handler, this);
      this.app = new App();
      this.app.options = options;
```
returning a `ReferenceError: options is not defined`  on the line 135 ` this.app.options = options; `


