### PR TITLE
Fix possible race condition in websocket heartbeat callback

### DIFF
--- a/src/trans-websocket.coffee
+++ b/src/trans-websocket.coffee
@@ -101,7 +101,8 @@ class WebSocketReceiver extends transport.GenericReceiver
             super
 
     heartbeat_timeout: ->
-        @session.close(3000, 'No response from heartbeat')
+        if @session?
+            @session.close(3000, 'No response from heartbeat')
 
 
 


### PR DESCRIPTION
Under load I was seeing cases where `heartbeat_timeout` was being called when the session had already been set to null.