### PR TITLE
Forward additional headers to detect SSL

### DIFF
--- a/src/transport.coffee
+++ b/src/transport.coffee
@@ -131,8 +131,9 @@ class Session
 
         headers = {}
         for key in ['referer', 'x-client-ip', 'x-forwarded-for', \
-                    'x-cluster-client-ip', 'via', 'x-real-ip', 'host', \
-                    'user-agent', 'accept-language']
+                    'x-cluster-client-ip', 'via', 'x-real-ip', \
+                    'x-forwarded-proto', 'x-ssl', \
+                    'host', 'user-agent', 'accept-language']
             headers[key] = req.headers[key] if req.headers[key]
         if headers
             @connection.headers = headers


### PR DESCRIPTION
When SSL is being offloaded by a middlebox one of these headers might be added
to the request.