### PR TITLE
Add "no-transform" to the no_cache headers

### DIFF
--- a/src/webjs.coffee
+++ b/src/webjs.coffee
@@ -175,7 +175,7 @@ exports.GenericApp = class GenericApp
         return content
 
     h_no_cache: (req, res, content) ->
-        res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+        res.setHeader('Cache-Control', 'no-store, no-cache, no-transform, must-revalidate, max-age=0')
         return content
 
     expect_form: (req, res, _data, next_filter) ->


### PR DESCRIPTION
I ran into an issue running meteor which user sockjs. My site didn't work when running on Chrome iOS with Google's [Data Saver](https://developer.chrome.com/multidevice/data-compression) feature turned on. 

I [filed a bug](https://code.google.com/p/chromium/issues/detail?id=553828#) but the change above *seems* to work around the issue for now until they can fix it on their side.