### PR TITLE
Allow configuring which headers are exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ Where `options` is a hash which can contain:
   connection have not been seen for a while. This delay is configured
   by this setting. By default the `close` event will be emitted when a
   receiving connection wasn't seen for 5 seconds.  </dd>
+
+<dt>allowed_headers (array of strings)</dt>
+<dd>A whitelist of HTTP headers exposed through connection's `headers`
+  object. By default only the following headers are exposed:
+  `referer`, `x-client-ip`, `x-forwarded-for`, `x-cluster-client-ip`,
+  `via`, `x-real-ip`, `x-forwarded-proto`, `x-ssl`, `host`,
+  `user-agent`, and `accept-language`.</dd>
 </dl>
 
 
@@ -212,9 +219,10 @@ has following methods and properties:
 <dt>Property: headers (object)</dt>
 <dd>Hash containing various headers copied from last receiving request
     on that connection. Exposed headers include: `origin`, `referer`
-    and `x-forwarded-for` (and friends). We explicitly do not grant
-    access to `cookie` header, as using it may easily lead to security
-    issues (for details read the section "Authorisation").</dd>
+    and `x-forwarded-for` (and friends). By default we explicitly do not
+    grant access to `cookie` header, as using it may easily lead to security
+    issues (for details read the section "Authorisation"). You can use
+    `allowed_headers` option to configure the whitelist.</dd>
 
 <dt>Property: url (string)</dt>
 <dd><a href="http://nodejs.org/docs/v0.4.10/api/http.html#request.url">Url</a>
@@ -414,9 +422,9 @@ Various issues and design considerations
 
 ### Authorisation
 
-SockJS-node does not expose cookies to the application. This is done
-deliberately as using cookie-based authorisation with SockJS simply
-doesn't make sense and will lead to security issues.
+SockJS-node by default does not expose cookies to the application.
+This is done deliberately as using cookie-based authorisation with
+SockJS simply doesn't make sense and will lead to security issues.
 
 Cookies are a contract between a browser and an http server, and are
 identified by a domain name. If a browser has a cookie set for

--- a/src/sockjs.coffee
+++ b/src/sockjs.coffee
@@ -142,6 +142,12 @@ class Server extends events.EventEmitter
             jsessionid: false
             heartbeat_delay: 25000
             disconnect_delay: 5000
+            allowed_headers: [
+                'referer', 'x-client-ip', 'x-forwarded-for',
+                'x-cluster-client-ip', 'via', 'x-real-ip',
+                'x-forwarded-proto', 'x-ssl',
+                'host', 'user-agent', 'accept-language'
+            ]
             log: (severity, line) -> console.log(line)
             sockjs_url: 'https://cdn.jsdelivr.net/sockjs/1.0.1/sockjs.min.js'
         if user_options

--- a/src/transport.coffee
+++ b/src/transport.coffee
@@ -61,6 +61,7 @@ class Session
     constructor: (@session_id, server) ->
         @heartbeat_delay = server.options.heartbeat_delay
         @disconnect_delay = server.options.disconnect_delay
+        @allowed_headers = server.options.allowed_headers
         @prefix = server.options.prefix
         @send_buffer = []
         @is_closing = false
@@ -130,10 +131,7 @@ class Session
         @connection.protocol = @recv.protocol
 
         headers = {}
-        for key in ['referer', 'x-client-ip', 'x-forwarded-for', \
-                    'x-cluster-client-ip', 'via', 'x-real-ip', \
-                    'x-forwarded-proto', 'x-ssl', \
-                    'host', 'user-agent', 'accept-language']
+        for key in @allowed_headers
             headers[key] = req.headers[key] if req.headers[key]
         if headers
             @connection.headers = headers


### PR DESCRIPTION
This is a backwards compatible change but I really think that it should be allowed which headers are available to the program, for better or worse. In my case I need some `x-` prefixed headers exposed by our reverse proxy so there is no way somebody could fake them (it sanitizes and sets them).

Fixes #198.
