### PR TITLE
Don't assume `res._header` exists

### DIFF
--- a/src/webjs.coffee
+++ b/src/webjs.coffee
@@ -120,8 +120,7 @@ exports.GenericApp = class GenericApp
     log_request: (req, res, data) ->
         td = (new Date()) - req.start_date
         @log('info', req.method + ' ' + req.url + ' ' + td + 'ms ' +
-                (if res.finished and res._header then res._header.split('\r')[0].split(' ')[1] \
-                                  else '(unfinished)'))
+                (if res.finished then res.statusCode else '(unfinished)'))
         return data
 
     log: (severity, line) ->

--- a/src/webjs.coffee
+++ b/src/webjs.coffee
@@ -120,7 +120,7 @@ exports.GenericApp = class GenericApp
     log_request: (req, res, data) ->
         td = (new Date()) - req.start_date
         @log('info', req.method + ' ' + req.url + ' ' + td + 'ms ' +
-                (if res.finished then res._header.split('\r')[0].split(' ')[1] \
+                (if res.finished and res._header then res._header.split('\r')[0].split(' ')[1] \
                                   else '(unfinished)'))
         return data
 


### PR DESCRIPTION
`res._header` is an internal implementation detail. Hence, some implementations of the http server do not set this. You can't blame them for this, because this is a hack.

[node-spdy](https://github.com/indutny/node-spdy) is an example.