### PR TITLE
Add option to disable CORS headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ Where `options` is a hash which can contain:
 
 <dt>disable_cors (boolean)</dt>
 <dd>Enabling this option will prevent
-  <a href="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing" target="_blank">CORS</a>
+  <a href="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing">CORS</a>
   headers from being included in the HTTP response. Can be used when the
-  sockjs client is know to be connecting from the same domain as the 
+  sockjs client is know to be connecting from the same origin as the 
   sockjs server.</dd>
 </dl>
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Where `options` is a hash which can contain:
 <dd>Enabling this option will prevent
   <a href="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing">CORS</a>
   headers from being included in the HTTP response. Can be used when the
-  sockjs client is know to be connecting from the same origin as the 
+  sockjs client is known to be connecting from the same origin as the 
   sockjs server.</dd>
 </dl>
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ Where `options` is a hash which can contain:
   connection have not been seen for a while. This delay is configured
   by this setting. By default the `close` event will be emitted when a
   receiving connection wasn't seen for 5 seconds.  </dd>
+
+<dt>disable_cors (boolean)</dt>
+<dd>Enabling this option will prevent
+  <a href="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing" target="_blank">CORS</a>
+  headers from being included in the HTTP response. Can be used when the
+  sockjs client is know to be connecting from the same domain as the 
+  sockjs server.</dd>
 </dl>
 
 

--- a/src/chunking-test.coffee
+++ b/src/chunking-test.coffee
@@ -33,7 +33,7 @@ exports.app =
     info: (req, res, _) ->
         info = {
             websocket: @options.websocket,
-            origins: ['*:*'],
+            origins: ['*:*'] unless @options.disable_cors,
             cookie_needed: not not @options.jsessionid,
             entropy: utils.random32(),
         }

--- a/src/trans-xhr.coffee
+++ b/src/trans-xhr.coffee
@@ -58,7 +58,7 @@ exports.app =
 
     xhr_cors: (req, res, content) ->
         if @options.disable_cors
-            return
+            return content
 
         if !req.headers['origin']
             origin = '*'

--- a/src/trans-xhr.coffee
+++ b/src/trans-xhr.coffee
@@ -57,6 +57,9 @@ exports.app =
         return true
 
     xhr_cors: (req, res, content) ->
+        if @options.disable_cors
+            return
+
         if !req.headers['origin']
             origin = '*'
         else


### PR DESCRIPTION
A relatively minor change to optionally disable the CORS headers. 

### Testing process

The following is refactored, but similar to the block of code that Meteor uses to set up sockjs in their ddp-server package.

Copy/paste the following code into the `tests/test_server/server.js` file, overwriting the contents of the existing file:

```javascript
var http = require('http');
var config = require('./config').config;
var sockjs = require('../../index');

var open_sockets = [];
var server = http.createServer();

var serverOptions = {
  prefix: '/sockjs',
  log: function() {},
  disable_cors: false, //change this setting to test
  heartbeat_delay: 45000,
  disconnect_delay: 60 * 1000,
  jsessionid: false
};

var meteor = sockjs.createServer(serverOptions);

meteor.on('connection', function (socket) {
  socket.send = function (data) {
    socket.write(data);
  };
  socket.on('close', function () {
    //open_sockets = _.without(open_sockets, socket);
  });
  open_sockets.push(socket);
  socket.send(JSON.stringify({server_id: "0"}));
});

meteor.installHandlers(server, {prefix: '/sockjs'});
server.listen(config.port, config.host);

console.log("[*] Listening on", config.host + ':' + config.port);
```

Run `npm install` and `make test_server` from the root folder of the project.

Open your browser and navigate to http://localhost:8081/sockjs/info. This will verify the old version of the info data is still returned.

Open another window and navigate to http://jsfiddle.net/bshamblen/4m118rbg/, then run the script. This will verify that you're able to load the info page from another domain.

Now, change the `disable_cors` option to `true` and restart the server.

Reload both pages above. The direct load of the page should not return the `options` key in the JSON body, but it should load, since it's not being called from another domain. The jsfiddle script should return an error, and the developer console should show that the CORS headers are missing.

Please let me know if you have any questions, or need me to make any adjustments.

