### PR TITLE
Updating sockjs-client CDN URL

### DIFF
--- a/src/sockjs.coffee
+++ b/src/sockjs.coffee
@@ -143,7 +143,7 @@ class Server extends events.EventEmitter
             heartbeat_delay: 25000
             disconnect_delay: 5000
             log: (severity, line) -> console.log(line)
-            sockjs_url: 'https://cdn.jsdelivr.net/sockjs/1.0.1/sockjs.min.js'
+            sockjs_url: 'https://cdn.jsdelivr.net/sockjs/1/sockjs.min.js'
         if user_options
             utils.objectExtend(@options, user_options)
 


### PR DESCRIPTION
As per #222 `sockjs_url` points to an old version of sockjs-client and could be updated