### PR TITLE
Bump `uuid`;

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "faye-websocket": "^0.10.0",
-    "uuid": "^2.0.2"
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "coffee-script": "^1.8.0"


### PR DESCRIPTION
`uuid@3.0.0` drops a couple of functions that aren't used.