### PR TITLE
Correct url match in proxy environment

### DIFF
--- a/src/sockjs.coffee
+++ b/src/sockjs.coffee
@@ -8,6 +8,7 @@ events = require('events')
 fs = require('fs')
 webjs = require('./webjs')
 utils = require('./utils')
+urlParser = require("url")
 
 trans_websocket = require('./trans-websocket')
 trans_jsonp = require('./trans-jsonp')
@@ -123,7 +124,8 @@ class Listener
 
     handler: (req, res, extra) =>
         # All urls that match the prefix must be handled by us.
-        if not req.url.match(@path_regexp)
+        url = urlParser.parse(req.url).pathname
+        if not url.match(@path_regexp)
             return false
         @webjs_handler(req, res, extra)
         return true


### PR DESCRIPTION
In the network proxy environment(like using SwitchyOmega, Charles), `req.url` is not pathname, but the full url, this situation may cause `sockjs` can not handle the request correctly.

Example:
Suppose there is a page： `http://www.example.com/test/index.html`.
And then start the sockjs server on `localhost:8080`, and then set the `options.prefix` to `/sockjs-node/info`. We will proxy  `www.example.com` to `localhost:8080`

At this point if the page send the request `http://www.example.com/sockjs-node/info`,  `req.url` is not `/sockjs-node/info`, but the `http://www.example.com/sockjs-nodeinfo`. 
So the check won't pass and sockjs won't work.