### PR TITLE
Now you can make new Access-Control-Allow-Origin header value

### DIFF
--- a/src/trans-xhr.coffee
+++ b/src/trans-xhr.coffee
@@ -65,6 +65,10 @@ exports.app =
         else
             origin = req.headers['origin']
             res.setHeader('Access-Control-Allow-Credentials', 'true')
+
+        if @options.custom_cors
+            origin = options.custom_cors(origin)
+
         res.setHeader('Access-Control-Allow-Origin', origin)
         res.setHeader('Vary', 'Origin')
         headers = req.headers['access-control-request-headers']

--- a/src/trans-xhr.coffee
+++ b/src/trans-xhr.coffee
@@ -67,7 +67,7 @@ exports.app =
             res.setHeader('Access-Control-Allow-Credentials', 'true')
 
         if @options.custom_cors
-            origin = options.custom_cors(origin)
+            origin = @options.custom_cors(origin)
 
         res.setHeader('Access-Control-Allow-Origin', origin)
         res.setHeader('Vary', 'Origin')


### PR DESCRIPTION
Now you can make new Access-Control-Allow-Origin header value, based on origin with custom rules.
Usage example:
```
sockjs.createServer({
    custom_cors: (origin) => {
        if (origin && example_service_re.test(origin)) {
            return origin;
        }
        return 'https://www.example.com';
    }
});
```