### PR TITLE
Fix sockjs version in package.json

### DIFF
--- a/examples/echo/package.json
+++ b/examples/echo/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "node-static": "^0.7.11",
-    "sockjs": "^0.4.0"
+    "sockjs": "^0.3.19"
   },
   "private": true
 }


### PR DESCRIPTION
This patch fix version of sockjs written in package.json.
We can see the latest version in npm(https://www.npmjs.com/package/sockjs).