### PR TITLE
Missing "origin" in allowedHeaders

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -146,7 +146,8 @@ class Session {
       'dnt',
       'host',
       'user-agent',
-      'accept-language'
+      'accept-language',
+      'origin'
     ];
     for (const key of allowedHeaders) {
       if (req.headers[key]) {


### PR DESCRIPTION
There is missing "origin" in allowedHeaders, docs says that it should be in connection.headers.