### PR TITLE
Change jQuery references to v3.4.1

### DIFF
--- a/examples/echo/index.html
+++ b/examples/echo/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html><head>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <style>
       .box {

--- a/examples/express/index.html
+++ b/examples/express/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html><head>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <style>
       .box {

--- a/examples/hapi/html/index.html
+++ b/examples/hapi/html/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html><head>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <style>
       .box {

--- a/examples/koa/index.html
+++ b/examples/koa/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html><head>
-    <script src="//cdn.jsdelivr.net/jquery/2.1.4/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <style>
       .box {

--- a/examples/multiplex/index.html
+++ b/examples/multiplex/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html><head>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <script src="https://d1fxtkz8shb9d2.cloudfront.net/websocket-multiplex-0.1.js"></script>
     <style>


### PR DESCRIPTION
Changes references to fix vulnerability. See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11358