### PR TITLE
Call res.write instead of res.end in writeHead

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,7 +17,7 @@ module.exports.fake_response = function fake_response(req, res) {
     r.push('');
     r.push('');
     try {
-      res.end(r.join('\r\n'));
+      res.write(r.join('\r\n'));
     } catch (x) {
       // intentionally empty
     }


### PR DESCRIPTION
This matches what Node.js does internally when dealing with a ServerResponse.

Fixes #252