### PR TITLE
Suppress error events.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,7 @@ module.exports.fake_response = function fake_response(req, res) {
     }
     r.push('');
     r.push('');
+    res.on('error', () => {});
     try {
       res.write(r.join('\r\n'));
     } catch (x) {


### PR DESCRIPTION
Fixes:
```js
node:events:353
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:213:20)
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:188:8)
    at emitErrorCloseNT (node:internal/streams/destroy:153:3)
    at processTicksAndRejections (node:internal/process/task_queues:80:21) {
  errno: -54,
  code: 'ECONNRESET',
  syscall: 'read'
}
npm ERR! code 1
```