### PR TITLE
Allow raw websocket connections to the base prefix.

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -1,12 +1,6 @@
 'use strict';
 
 module.exports = {
-  welcome_screen(req, res) {
-    res.setHeader('Content-Type', 'text/plain; charset=UTF-8');
-    res.writeHead(200);
-    res.end('Welcome to SockJS!\n');
-  },
-
   handle_404(req, res) {
     res.setHeader('Content-Type', 'text/plain; charset=UTF-8');
     res.writeHead(404);

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -11,7 +11,6 @@ module.exports.generateDispatcher = function generateDispatcher(options) {
   const p = (s) => new RegExp(`^${options.prefix}${s}[/]?$`);
   const t = (s) => [p(`/([^/.]+)/([^/.]+)${s}`), 'server', 'session'];
   const prefix_dispatcher = [
-    ['GET', p(''), [handlers.welcome_screen]],
     ['OPTIONS', p('/info'), [middleware.h_sid, middleware.xhr_cors, info.info_options]],
     ['GET', p('/info'), [middleware.xhr_cors, middleware.h_no_cache, info.info]]
   ];
@@ -21,7 +20,9 @@ module.exports.generateDispatcher = function generateDispatcher(options) {
 
   const transport_dispatcher = [];
 
-  for (const name of options.transports) {
+  const transports = options.transports.concat(['welcome']);
+
+  for (const name of transports) {
     const tr = transportList[name];
     if (!tr) {
       throw new Error(`unknown transport ${name}`);

--- a/lib/transport/list.js
+++ b/lib/transport/list.js
@@ -7,5 +7,6 @@ module.exports = {
   websocket: require('./websocket'),
   'websocket-raw': require('./websocket-raw'),
   'xhr-polling': require('./xhr-polling'),
-  'xhr-streaming': require('./xhr-streaming')
+  'xhr-streaming': require('./xhr-streaming'),
+  welcome: require('./welcome')
 };

--- a/lib/transport/websocket-raw.js
+++ b/lib/transport/websocket-raw.js
@@ -5,6 +5,7 @@ const Session = require('../session');
 const Transport = require('./transport');
 const SockJSConnection = require('../sockjs-connection');
 const middleware = require('../middleware');
+const welcome = require('./welcome');
 
 class RawWebsocketSessionReceiver {
   constructor(req, conn, server, ws) {
@@ -85,8 +86,21 @@ function raw_websocket(req, socket, head, next) {
   next();
 }
 
+function welcome_websocket(req, res, head, next) {
+  if (!FayeWebsocket.isWebSocket(req)) {
+    welcome.welcome_screen(req, res);
+  }
+  next();
+}
+
 module.exports = {
   routes: [
+    {
+      method: 'GET',
+      path: '',
+      handlers: [welcome_websocket, raw_websocket],
+      transport: false
+    },
     {
       method: 'GET',
       path: '/websocket',

--- a/lib/transport/welcome.js
+++ b/lib/transport/welcome.js
@@ -1,0 +1,19 @@
+'use strict';
+
+function welcome_screen(req, res) {
+  res.setHeader('Content-Type', 'text/plain; charset=UTF-8');
+  res.writeHead(200);
+  res.end('Welcome to SockJS!\n');
+}
+
+module.exports = {
+  welcome_screen,
+  routes: [
+    {
+      method: 'GET',
+      path: '',
+      handlers: [welcome_screen],
+      transport: false
+    }
+  ]
+};


### PR DESCRIPTION
This allows accepting websocket connections from non-sockjs clients without having to append `/websocket` to the url.

This is handy if one wants/requires a specific websocket url endpoint without a `/websocket` suffix for non-sockjs clients.

This should be fully backwards compatible as websocket requests to the url prefix fail currently.