### PR TITLE
attach is not the function. It should be attachServer for connecting with the sockjs

### DIFF
--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -17,7 +17,7 @@ const app = express();
 app.get('/', (req, res) => res.sendFile(__dirname + '/index.html'));
 
 const server = http.createServer(app);
-sockjs_echo.attach(server);
+sockjs_echo.attachServer(server);
 
 server.listen(9999, '0.0.0.0', () => {
   console.log(' [*] Listening on 0.0.0.0:9999');


### PR DESCRIPTION
In the example for express setup. To connect the HTTP server with the Sockjs. We have to use attachServer function instead of attach.