### PR TITLE
fix: replace `uuid` package with custom implementation

### DIFF
--- a/lib/sockjs-connection.js
+++ b/lib/sockjs-connection.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('sockjs:connection');
 const stream = require('stream');
-const { v4: uuid } = require('uuid');
+const { uuid } = require('./utils');
 
 class SockJSConnection extends stream.Duplex {
   constructor(session) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,11 @@ const crypto = require('crypto');
 const http = require('http');
 
 module.exports.uuid = function uuid() {
+  // only available on Node v16.7+
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
   const bytes = crypto.randomBytes(16);
 
   // Per RFC 4122 §4.4:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,31 @@
 const crypto = require('crypto');
 const http = require('http');
 
+module.exports.uuid = function uuid() {
+  const bytes = crypto.randomBytes(16);
+
+  // Per RFC 4122 §4.4:
+  // Set version to 4 => xxxx -> 0100
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+
+  // Set variant to RFC 4122 => 10xxxxxx
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = bytes.toString('hex');
+
+  return (
+    hex.slice(0, 8) +
+    '-' +
+    hex.slice(8, 12) +
+    '-' +
+    hex.slice(12, 16) +
+    '-' +
+    hex.slice(16, 20) +
+    '-' +
+    hex.slice(20)
+  );
+};
+
 // used in case of 'upgrade' requests where res is
 // net.Socket instead of http.ServerResponse
 module.exports.fake_response = function fake_response(req, res) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "sockjs",
       "version": "0.4.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.1",
-        "faye-websocket": "^0.11.3",
-        "uuid": "^8.1.0"
+        "faye-websocket": "^0.11.3"
       },
       "devDependencies": {
         "eslint": "^7.32.0",
@@ -1408,14 +1408,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
-      "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   ],
   "dependencies": {
     "debug": "^4.3.1",
-    "faye-websocket": "^0.11.3",
-    "uuid": "^8.1.0"
+    "faye-websocket": "^0.11.3"
   },
   "devDependencies": {
     "eslint": "^7.32.0",


### PR DESCRIPTION
Versions of `uuid` before v14 are impacted by GHSA-w5hq-g745-h8pq which isn't exploitable in this package but given this package is used by popular libraries such as `webpack-dev-server` it'll create a lot of noise.

I've replaced the dependency with a custom UUID v4 generator to avoid having to drop Node versions, though if people are willing to drop support up to Node v16.7+ then the native `crypto.randomUUID` function can be used

Resolves #316