### PR TITLE
Make ./scripts/test.sh pass successfully by running under Python 2

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,13 +13,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-        architecture: 'x64'
-    - name: Install virtualenv
-      run: |
-        pip install virtualenv
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,16 +11,17 @@ sleep 1
 
 set +e
 
-DOCKER_NETWORK_ARGS="--add-host host.docker.internal:host-gateway"
+REPO_ROOT="$(pwd)"
+DOCKER_NETWORK_ARGS=(--add-host host.docker.internal:host-gateway)
 if [ "$(uname -s)" = "Linux" ] && [ -n "${CI:-}" ]; then
-  DOCKER_NETWORK_ARGS="--network host"
+  DOCKER_NETWORK_ARGS=(--network host)
 fi
 
 docker run \
        --rm \
-       --volume $(pwd):$(pwd) \
-       --workdir $(pwd)/sockjs-protocol \
-       ${DOCKER_NETWORK_ARGS} \
+       --volume "${REPO_ROOT}:${REPO_ROOT}" \
+       --workdir "${REPO_ROOT}/sockjs-protocol" \
+       "${DOCKER_NETWORK_ARGS[@]}" \
        python:2.7 \
        sh -c 'make test_deps pycco_deps && ./venv/bin/python sockjs-protocol.py'
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,17 +4,21 @@ set -e
 
 rm -rf sockjs-protocol
 git clone --depth=1 https://github.com/sockjs/sockjs-protocol.git
-cd sockjs-protocol
-make test_deps pycco_deps
-cd ..
+
 node tests/test_server/server.js &
 SRVPID=$!
 sleep 1
 
 set +e
 
-cd sockjs-protocol
-./venv/bin/python sockjs-protocol.py
+docker run \
+       --rm \
+       --volume $(pwd):$(pwd) \
+       --workdir $(pwd)/sockjs-protocol \
+       --network host \
+       python:2.7 \
+       sh -c 'make test_deps pycco_deps && ./venv/bin/python sockjs-protocol.py'
+
 PASSED=$?
 kill $SRVPID
 exit $PASSED

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,11 +11,16 @@ sleep 1
 
 set +e
 
+DOCKER_NETWORK_ARGS="--add-host host.docker.internal:host-gateway"
+if [ "$(uname -s)" = "Linux" ] && [ -n "${CI:-}" ]; then
+  DOCKER_NETWORK_ARGS="--network host"
+fi
+
 docker run \
        --rm \
        --volume $(pwd):$(pwd) \
        --workdir $(pwd)/sockjs-protocol \
-       --network host \
+       ${DOCKER_NETWORK_ARGS} \
        python:2.7 \
        sh -c 'make test_deps pycco_deps && ./venv/bin/python sockjs-protocol.py'
 


### PR DESCRIPTION
The ./scripts/test.sh script only supports Python 2, but CI was invoking it with Python 3, causing it to fail on every run. This meant CI results did not provide confidence that a given change was sound.

This change updates CI to run the test suite using Python 2, which is the only supported version. Once the upstream sockjs-protocol test suite adds Python 3 support, the project can switch back.

CI is now green.